### PR TITLE
Flow Join 用の hint を追加

### DIFF
--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/optimizer/joins.scala
@@ -503,6 +503,11 @@ trait JoinSelectionHelper extends Logging {
     hint.rightHint.exists(_.strategy.contains(NO_BROADCAST_AND_REPLICATION))
   }
 
+  def hintToFlowJoin(hint: JoinHint): Boolean = {
+    hint.leftHint.exists(_.strategy.contains(FLOW)) ||
+      hint.rightHint.exists(_.strategy.contains(FLOW))
+  }
+
   private def getBuildSide(
       canBuildLeft: Boolean,
       canBuildRight: Boolean,

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/hints.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/hints.scala
@@ -127,7 +127,8 @@ object JoinStrategyHint {
     BROADCAST,
     SHUFFLE_MERGE,
     SHUFFLE_HASH,
-    SHUFFLE_REPLICATE_NL)
+    SHUFFLE_REPLICATE_NL,
+    FLOW)
 }
 
 /**
@@ -195,6 +196,14 @@ case object PREFER_SHUFFLE_HASH extends JoinStrategyHint {
 case object NO_BROADCAST_AND_REPLICATION extends JoinStrategyHint {
   override def displayName: String = "no_broadcast_and_replication"
   override def hintAliases: Set[String] = Set.empty
+}
+
+case object FLOW extends JoinStrategyHint {
+  override def displayName: String = "flow_join"
+  override def hintAliases: Set[String] = Set(
+    "FLOW",
+    "FLOW_JOIN"
+  )
 }
 
 abstract class AggregateHint;

--- a/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
+++ b/sql/catalyst/src/main/scala/org/apache/spark/sql/internal/SQLConf.scala
@@ -5587,6 +5587,16 @@ object SQLConf {
       .booleanConf
       .createWithDefault(true)
 
+  val FORCE_FLOW_JOIN_EXEC =
+    buildConf("spark.sql.forceFlowJoin.enabled")
+      .internal()
+      .doc(
+        "Use FlowJoinExec."
+      )
+      .version("proof-ninja fork")
+      .booleanConf
+      .createWithDefault(false)
+
   /**
    * Holds information about keys that have been deprecated.
    *
@@ -6592,6 +6602,8 @@ class SQLConf extends Serializable with Logging with SqlApiConf {
   def legacyCodingErrorAction: Boolean = getConf(SQLConf.LEGACY_CODING_ERROR_ACTION)
 
   def legacyEvalCurrentTime: Boolean = getConf(SQLConf.LEGACY_EVAL_CURRENT_TIME)
+
+  def forceFlowJoinExec: Boolean = getConf(SQLConf.FORCE_FLOW_JOIN_EXEC)
 
   /** ********************** SQLConf functionality methods ************ */
 

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -285,6 +285,29 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
           }
         }
 
+        def createFlowJoin(onlyLookingAtHint: Boolean) = {
+          if (hashJoinSupport) {
+            val brBuildSide = getBroadcastBuildSide(j, onlyLookingAtHint, conf)
+            checkHintBuildSide(onlyLookingAtHint, brBuildSide, joinType, hint, isBroadcast = true)
+            val shBuildSide = getShuffleHashJoinBuildSide(j, onlyLookingAtHint, conf)
+            checkHintBuildSide(onlyLookingAtHint, shBuildSide, joinType, hint, isBroadcast = false)
+            brBuildSide.zip(shBuildSide).map {
+              case (brBuildSide, shBuildSide) =>
+                Seq(joins.FlowJoinExec(
+                  leftKeys,
+                  rightKeys,
+                  joinType,
+                  brBuildSide,
+                  shBuildSide,
+                  nonEquiCond,
+                  planLater(left),
+                  planLater(right)))
+            }
+          } else {
+            None
+          }
+        }
+
         def createCartesianProduct() = {
           if (joinType.isInstanceOf[InnerLike] && !hintToNotBroadcastAndReplicate(hint)) {
             // `CartesianProductExec` can't implicitly evaluate equal join condition, here we should
@@ -311,7 +334,25 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
             }
         }
 
-        if (hint.isEmpty) {
+        if (conf.forceFlowJoinExec) {
+          createFlowJoin(true)
+            .orElse(createFlowJoin(false))
+            .orElse {
+              if (hashJoinSupport) {
+                val buildSide = getSmallerSide(left, right)
+                Some(Seq(joins.FlowJoinExec(
+                  leftKeys,
+                  rightKeys,
+                  joinType,
+                  buildSide,
+                  buildSide,
+                  nonEquiCond,
+                  planLater(left),
+                  planLater(right))))
+              } else None
+            }
+            .getOrElse(createJoinWithoutHint())
+        } else if (hint.isEmpty) {
           createJoinWithoutHint()
         } else {
           createBroadcastHashJoin(true)

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/SparkStrategies.scala
@@ -355,7 +355,26 @@ abstract class SparkStrategies extends QueryPlanner[SparkPlan] {
         } else if (hint.isEmpty) {
           createJoinWithoutHint()
         } else {
-          createBroadcastHashJoin(true)
+          {
+            if (hintToFlowJoin(hint)) {
+              createFlowJoin(true)
+                .orElse(createFlowJoin(false))
+                .orElse {
+                  if (hashJoinSupport) {
+                    val buildSide = getSmallerSide(left, right)
+                    Some(Seq(joins.FlowJoinExec(
+                      leftKeys,
+                      rightKeys,
+                      joinType,
+                      buildSide,
+                      buildSide,
+                      nonEquiCond,
+                      planLater(left),
+                      planLater(right))))
+                  } else None
+                }
+            } else None
+          }.orElse(createBroadcastHashJoin(true))
             .orElse { if (hintToSortMergeJoin(hint)) createSortMergeJoin() else None }
             .orElse(createShuffleHashJoin(true))
             .orElse { if (hintToShuffleReplicateNL(hint)) createCartesianProduct() else None }

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/FlowJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/FlowJoinExec.scala
@@ -34,7 +34,8 @@ case class FlowJoinExec(
   leftKeys: Seq[Expression],
   rightKeys: Seq[Expression],
   joinType: JoinType,
-  buildSide: BuildSide,
+  brBuildSide: BuildSide,
+  shBuildSide: BuildSide,
   condition: Option[Expression],
   left: SparkPlan,
   right: SparkPlan,
@@ -102,10 +103,10 @@ case class FlowJoinExec(
     val (rightBr, rightSc) = split[Any](rightResults, rightKeyReference, heavyHitters)
 
     val broadcastHashJoinExec = BroadcastHashJoinExec(
-      leftKeys, rightKeys, joinType, buildSide, condition, leftBr, rightBr
+      leftKeys, rightKeys, joinType, brBuildSide, condition, leftBr, rightBr
     )
     val shuffledHashJoinExec = ShuffledHashJoinExec(
-      leftKeys, rightKeys, joinType, buildSide, condition, leftSc, rightSc, isSkewJoin = false
+      leftKeys, rightKeys, joinType, shBuildSide, condition, leftSc, rightSc, isSkewJoin = false
     )
 
     val broadcastHashJoinResults = sparkSession.createDataFrame(

--- a/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/FlowJoinExec.scala
+++ b/sql/core/src/main/scala/org/apache/spark/sql/execution/joins/FlowJoinExec.scala
@@ -1,0 +1,125 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql.execution.joins
+
+import scala.jdk.CollectionConverters._
+
+import org.apache.spark.SparkException
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.{DataFrame, Encoders, Row}
+import org.apache.spark.sql.catalyst.InternalRow
+import org.apache.spark.sql.catalyst.expressions.{Attribute, AttributeReference, AttributeSeq, BoundReference, Expression, UnsafeRow}
+import org.apache.spark.sql.catalyst.optimizer.BuildSide
+import org.apache.spark.sql.catalyst.plans.JoinType
+import org.apache.spark.sql.catalyst.plans.logical.CatalystSerde
+import org.apache.spark.sql.execution.{ExternalRDDScanExec, SparkPlan}
+import org.apache.spark.sql.execution.metric.SQLMetrics
+
+case class FlowJoinExec(
+  leftKeys: Seq[Expression],
+  rightKeys: Seq[Expression],
+  joinType: JoinType,
+  buildSide: BuildSide,
+  condition: Option[Expression],
+  left: SparkPlan,
+  right: SparkPlan,
+  heavyHitters: Seq[RDD[UnsafeRow]] = Seq.empty
+) extends BaseJoinExec {
+
+  override def output: Seq[Attribute] = left.output ++ right.output
+
+  override lazy val metrics = Map(
+    "numOutputRows" -> SQLMetrics.createMetric(sparkContext, "number of output rows"))
+
+  private def bindReference(
+    expressions: Seq[Expression],
+    input: AttributeSeq
+  ): BoundReference =
+    expressions match {
+      case Seq(a: AttributeReference) =>
+        val ordinal = input.indexOf(a.exprId)
+        if (ordinal == -1) {
+          throw SparkException.internalError(
+            s"Couldn't find $a in ${input.attrs.mkString("[", ",", "]")}"
+          )
+        } else {
+          BoundReference(ordinal, a.dataType, input(ordinal).nullable)
+        }
+    }
+
+  private def createPlan(table: DataFrame): SparkPlan =
+    ExternalRDDScanExec(CatalystSerde.generateObjAttr[Row](Encoders.row(table.schema)), table.rdd)
+
+  private def split[T](
+    table: DataFrame,
+    col: BoundReference,
+    heavyHitters: Set[T]
+  ): (SparkPlan, SparkPlan) = {
+    val idx = col.ordinal
+    (
+      createPlan(table.filter(row => heavyHitters(row.getAs[T](idx)))),
+      createPlan(table.filter(row => !heavyHitters(row.getAs[T](idx))))
+    )
+  }
+
+  protected override def doExecute(): RDD[InternalRow] = {
+    val numOutputRows = longMetric("numOutputRows")
+
+    val sparkSession = left.session
+
+    val leftResults = sparkSession.createDataFrame(
+      left.executeCollectPublic().toList.asJava,
+      left.schema
+    )
+    val rightResults = sparkSession.createDataFrame(
+      right.executeCollectPublic().toList.asJava,
+      right.schema
+    )
+
+    val leftKeyReference = bindReference(leftKeys, left.output)
+    val rightKeyReference = bindReference(rightKeys, right.output)
+
+    // TODO load from files
+    // TODO remove Any
+    val heavyHitters = Set.empty[Any]
+
+    val (leftBr, leftSc) = split[Any](leftResults, leftKeyReference, heavyHitters)
+    val (rightBr, rightSc) = split[Any](rightResults, rightKeyReference, heavyHitters)
+
+    val broadcastHashJoinExec = BroadcastHashJoinExec(
+      leftKeys, rightKeys, joinType, buildSide, condition, leftBr, rightBr
+    )
+    val shuffledHashJoinExec = ShuffledHashJoinExec(
+      leftKeys, rightKeys, joinType, buildSide, condition, leftSc, rightSc, isSkewJoin = false
+    )
+
+    val broadcastHashJoinResults = sparkSession.createDataFrame(
+      broadcastHashJoinExec.executeCollectPublic().toList.asJava,
+      broadcastHashJoinExec.schema
+    )
+    val shuffledHashJoinResults = sparkSession.createDataFrame(
+      shuffledHashJoinExec.executeCollectPublic().toList.asJava,
+      shuffledHashJoinExec.schema
+    )
+    createPlan(broadcastHashJoinResults.union(shuffledHashJoinResults)).execute()
+  }
+
+  override protected def withNewChildrenInternal(
+    newLeft: SparkPlan, newRight: SparkPlan): FlowJoinExec =
+    copy(left = newLeft, right = newRight)
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/FlowJoinExecSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/FlowJoinExecSuite.scala
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.sql.catalyst.optimizer.JoinSelectionHelper
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.execution.joins.FlowJoinExec
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+class FlowJoinExecSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlanHelper
+  with JoinSelectionHelper {
+
+  import testImplicits._
+
+  setupTestData()
+
+  test("equi-join is flow-join") {
+    withSQLConf(SQLConf.FORCE_FLOW_JOIN_EXEC.key -> "true") {
+      val x = testData2.as("x")
+      val y = testData2.as("y")
+
+      val join = x.join(y, $"x.a" === $"y.a", "inner").queryExecution.optimizedPlan
+      val planned = spark.sessionState.planner.JoinSelection(join)
+      assert(planned.size === 1)
+      assert(planned.head.isInstanceOf[FlowJoinExec])
+    }
+  }
+
+  // ==== failed ====
+  // org.apache.spark.SparkUnsupportedOperationException:
+  // Scan does not implement doExecuteBroadcast.
+  test("inner join where, one match per row") {
+    withSQLConf(SQLConf.FORCE_FLOW_JOIN_EXEC.key -> "true") {
+      withSQLConf(SQLConf.CASE_SENSITIVE.key -> "true") {
+        checkAnswer(
+          upperCaseData.join(lowerCaseData).where($"n" === $"N"),
+          Seq(
+            Row(1, "A", 1, "a"),
+            Row(2, "B", 2, "b"),
+            Row(3, "C", 3, "c"),
+            Row(4, "D", 4, "d")
+          ))
+      }
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/FlowJoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/FlowJoinSuite.scala
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.sql.catalyst.optimizer.JoinSelectionHelper
+import org.apache.spark.sql.execution.adaptive.AdaptiveSparkPlanHelper
+import org.apache.spark.sql.execution.joins._
+import org.apache.spark.sql.internal.SQLConf
+import org.apache.spark.sql.test.SharedSparkSession
+
+
+class FlowJoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlanHelper
+  with JoinSelectionHelper {
+  import testImplicits._
+
+  setupTestData()
+
+  def statisticSizeInByte(df: classic.DataFrame): BigInt = {
+    df.queryExecution.optimizedPlan.stats.sizeInBytes
+  }
+
+  test("flow join from hint") {
+    withSQLConf(SQLConf.FORCE_FLOW_JOIN_EXEC.key -> "false") {
+      spark.sharedState.cacheManager.clearCache()
+      val df = testData.hint("flow_join").join(testData2, $"key" === $"a")
+      val physical = df.queryExecution.sparkPlan
+      val operators = physical.collect {
+        case j: BroadcastHashJoinExec => j
+        case j: ShuffledHashJoinExec => j
+        case j: CartesianProductExec => j
+        case j: BroadcastNestedLoopJoinExec => j
+        case j: SortMergeJoinExec => j
+        case j: FlowJoinExec => j
+      }
+
+      assert(operators.size === 1)
+      assert(operators.head.getClass === classOf[FlowJoinExec])
+    }
+  }
+
+  test("flow join from hint 2") {
+    withSQLConf(SQLConf.FORCE_FLOW_JOIN_EXEC.key -> "false") {
+      spark.sharedState.cacheManager.clearCache()
+      val df = testData.join(testData2.hint("flow_join"), $"key" === $"a")
+      val physical = df.queryExecution.sparkPlan
+      val operators = physical.collect {
+        case j: BroadcastHashJoinExec => j
+        case j: ShuffledHashJoinExec => j
+        case j: CartesianProductExec => j
+        case j: BroadcastNestedLoopJoinExec => j
+        case j: SortMergeJoinExec => j
+        case j: FlowJoinExec => j
+      }
+
+      assert(operators.size === 1)
+      assert(operators.head.getClass === classOf[FlowJoinExec])
+    }
+  }
+}

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinHintSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinHintSuite.scala
@@ -72,6 +72,16 @@ class JoinHintSuite extends PlanTest with SharedSparkSession with AdaptiveSparkP
     assert(joinHints == expectedHints)
   }
 
+  test("flow join") {
+    verifyJoinHint(
+      df.hint("flow_join").join(df, "id"),
+      JoinHint(
+        Some(HintInfo(strategy = Some(FLOW))),
+        None
+      ) :: Nil
+    )
+  }
+
   test("single join") {
     verifyJoinHint(
       df.hint("broadcast").join(df, "id"),

--- a/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
+++ b/sql/core/src/test/scala/org/apache/spark/sql/JoinSuite.scala
@@ -58,6 +58,26 @@ class JoinSuite extends QueryTest with SharedSparkSession with AdaptiveSparkPlan
     assert(planned.size === 1)
   }
 
+  test("flow join from hint") {
+    withSQLConf(SQLConf.FORCE_FLOW_JOIN_EXEC.key -> "false") {
+      spark.sharedState.cacheManager.clearCache()
+      val df = testData.hint("flow_join").join(testData2, $"key" === $"a")
+      val physical = df.queryExecution.sparkPlan
+      val optimized = df.queryExecution.optimizedPlan
+      val operators = physical.collect {
+        case j: BroadcastHashJoinExec => j
+        case j: ShuffledHashJoinExec => j
+        case j: CartesianProductExec => j
+        case j: BroadcastNestedLoopJoinExec => j
+        case j: SortMergeJoinExec => j
+        case j: FlowJoinExec => j
+      }
+
+      assert(operators.size === 1)
+      assert(operators.head.getClass === classOf[FlowJoinExec])
+    }
+  }
+
   def assertJoin(pair: (String, Class[_ <: BinaryExecNode])): Any = {
     val sqlString = pair._1
     val c = pair._2


### PR DESCRIPTION
## Flow Join 用のヒントを追加

https://github.com/proof-ninja/spark/pull/4/commits/b573f5bcd26ad9ad8fd6c7fd956c496e676e75d4

単体テストで動作確認を行った。

```
sbt> sql/Test/testOnly *.FlowJoinSuite
```